### PR TITLE
[CI] Bump ruby versions to verify support for latest stable 3.x

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Technically no longer maintained Ruby releases, but lets still test them:
           - ruby-version: "2.6.10"
             rails-version: "4.2"
           - ruby-version: "2.7.8"
@@ -25,11 +26,13 @@ jobs:
             rails-version: "6.1"
           - ruby-version: "2.7.8"
             rails-version: "7.0"
-          - ruby-version: "3.1.4"
+          # Security maintenance releases:
+          - ruby-version: "3.1.5"
             rails-version: "7.0"
-          - ruby-version: "3.2.3"
+          # Stable releases:
+          - ruby-version: "3.2.4"
             rails-version: "7.1"
-          - ruby-version: "3.3.0"
+          - ruby-version: "3.3.3"
             rails-version: "7.1"
     services:
       postgres:


### PR DESCRIPTION
confirm on CI that this gem still works on the latest ruby versions